### PR TITLE
Fix link in README and add clarifying sentence about the purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The free-thinking of one's age is the common sense of the next. -Matthew Arnold
 ```
 
-`treeThinking` was inspired by the desire to convert the output of `sklearn`'s `DecisionTreeClassifier` models into something more useful.
+`treeThinking` was inspired by the desire to convert the output of `sklearn`'s `DecisionTreeClassifier` models into something more useful. In this case, `treeThinking` outputs its representation to a language-agnostic YAML file which can be consumed by other software for parsing.
 
 This project and schema emerged from conversations with [@greggroth](https://github.com/greggroth) at [Blue Bottle Coffee](https://github.com/bluebottlecoffee).
 
@@ -137,7 +137,7 @@ Not sorry for the bad pun. Am sorry I didn't go with `Lorax`, but copyright, y'k
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [https://github.com/bluebottlecoffee/eatl](https://github.com/bluebottlecoffee/eatl). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [https://github.com/BBischof/treeThinking](https://github.com/BBischof/treeThinking). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.
 
 ## License
 


### PR DESCRIPTION
I wanted to give people a better idea of what treeThinking does without having to parse through the entire readme. This adds one sentence that I hope makes the value of this software more clear upon first glance.

I also fixed one link the readme which was likely a copy / paste error.